### PR TITLE
Add gradient background to posts pages

### DIFF
--- a/src/routes/posts/+layout.svelte
+++ b/src/routes/posts/+layout.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	export let data;
+</script>
+
+<slot />
+
+<style>
+	:global(html) {
+		background: linear-gradient(to bottom, #fffaef 0%, #fffdfa 100%);
+	}
+</style>


### PR DESCRIPTION
## Summary
- create a layout for `/posts` to add a gradient background

## Testing
- `npm run lint` *(fails: parsing errors in existing files)*
- `npm run check` *(fails: svelte-check found 2 errors and 265 warnings)*